### PR TITLE
fix: add default cmd for container image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,3 +15,4 @@ FROM public.ecr.aws/docker/library/alpine:3.20
 COPY --from=builder /ssm-diff/dist/ssm-diff /usr/local/bin/ssm-diff
 
 ENTRYPOINT ["ssm-diff"]
+CMD ["--help"]


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->

## How Has This Been Tested?
<!--- Please describe how you tested your changes -->
- [ ] I have executed `pre-commit run -a` on my pull request
